### PR TITLE
fix compatibility with bitarray 2.0.0+ and fix fluxengine a2r files

### DIFF
--- a/passport/__init__.py
+++ b/passport/__init__.py
@@ -727,7 +727,11 @@ class Convert(BasePassportProcessor):
         if physical_sectors:
             b = bitarray.bitarray(endian="big")
             for s in physical_sectors.values():
-                b.extend(track.bits[s.start_bit_index:s.end_bit_index])
+                if s.start_bit_index <= s.end_bit_index:
+                    b.extend(track.bits[s.start_bit_index:s.end_bit_index])
+                else:
+                    b.extend(track.bits[s.start_bit_index:])
+                    b.extend(track.bits[:s.end_bit_index])
         else:
             # TODO call wozify here instead
             b = track.bits[:51021]

--- a/passport/wozardry.py
+++ b/passport/wozardry.py
@@ -578,7 +578,7 @@ class WozDiskImage:
             block_size = len(padded_bytes) // 512
             starting_block += block_size
             trk_chunk.extend(to_uint16(block_size))
-            trk_chunk.extend(to_uint32(track.bits.length()))
+            trk_chunk.extend(to_uint32(len(track.bits)))
             bits_chunk.extend(padded_bytes)
         for i in range(len(self.tracks), 160):
             trk_chunk.extend(to_uint16(0))


### PR DESCRIPTION
Hi!

I'm working on adding .a2r support to [fluxengine](https://github.com/davidgiven/fluxengine). I ran into an exception with `passport.py convert`:
```
Traceback (most recent call last):
  File "/home/jepler/src/passport.py/passport/__init__.py", line 757, in postprocess
    wozardry.WozDiskImage(io.BytesIO(bytes(woz_image)))
  File "/home/jepler/src/passport.py/passport/wozardry.py", line 475, in __bytes__
    return self.dump()
  File "/home/jepler/src/passport.py/passport/wozardry.py", line 481, in dump
    trks = self._dump_trks()
  File "/home/jepler/src/passport.py/passport/wozardry.py", line 550, in _dump_trks
    return self._dump_trks_v2()
  File "/home/jepler/src/passport.py/passport/wozardry.py", line 581, in _dump_trks_v2
    trk_chunk.extend(to_uint32(track.bits.length()))
AttributeError: 'bitarray.bitarray' object has no attribute 'length'
```

This is due to an incompatible change in bitarray: https://github.com/ilanschnell/bitarray/blob/2.4.0/CHANGE_LOG#L160
>   * remove `.length()` method (deprecated since 1.5.1 - use `len()`)

This also closes #3.